### PR TITLE
Fixed migration drop functionality on the updatedUsersTable1 migration

### DIFF
--- a/data/migrations/20220408020725_updateUsersTable1.js
+++ b/data/migrations/20220408020725_updateUsersTable1.js
@@ -15,8 +15,9 @@ exports.up = function (knex) {
  * @returns { Promise<void> }
  */
 exports.down = function (knex) {
-    return knex.schema
-        .dropTableIfExists("follows")
-        .dropTableIfExists("posts")
-        .dropTableIfExists("users");
+    return knex.schema.table("users", (tbl) => {
+        tbl.dropColumn("bio");
+        tbl.dropColumn("location");
+        tbl.dropColumn("website");
+    });
 };


### PR DESCRIPTION
This should allow the changes to be correctly dropped when migrating down and not delete the entire table, just the columns added. 